### PR TITLE
Update requirement of SDWebImage to 4.x

### DIFF
--- a/UIActivityIndicator-for-SDWebImage.podspec
+++ b/UIActivityIndicator-for-SDWebImage.podspec
@@ -7,8 +7,8 @@ Pod::Spec.new do |s|
   s.license       = { :type => 'MIT License', :file => 'LICENSE.txt' }
   s.author        = { "Giacomo Saccardo" => "gsaccardo@gmail.com" }
   s.source        = { :git => "https://github.com/JJSaccolo/UIActivityIndicator-for-SDWebImage.git", :tag => "1.2" }
-  s.platform      = :ios, '5.0'
+  s.platform      = :ios, '8.0'
   s.source_files  = '*.{h,m}'
   s.requires_arc  = true
-  s.dependency 'SDWebImage', '~> 3.7'
+  s.dependency 'SDWebImage', '~> 4.0'
 end


### PR DESCRIPTION
[!] CocoaPods could not find compatible versions for pod "SDWebImage":
  In snapshot (Podfile.lock):
    SDWebImage (= 4.4.7, ~> 4.0, ~> 4.4.7)

  In Podfile:
    SDWebImage (~> 4.4.7)

    UIActivityIndicator-for-SDWebImage (from `https://github.com/sunnyspan/UIActivityIndicator-for-SDWebImage.git`) was resolved to 1.2, which depends on
      SDWebImage (~> 3.7)

Specs satisfying the `SDWebImage (~> 4.4.7), SDWebImage (= 4.4.7, ~> 4.0, ~> 4.4.7), SDWebImage (~> 3.7)` dependency were found, but they required a higher minimum deployment target.